### PR TITLE
Correção

### DIFF
--- a/book3/02-variables.mkd
+++ b/book3/02-variables.mkd
@@ -735,7 +735,7 @@ Valor a ser pago: 96.25
 Não vamos nos preocupar em garantir que nosso pagamento tenha exatamente dois dígitos após a casa decimal por enquanto.  Se você quiser, você pode utilizar com a função nativa do Python `round` função para arredondar corretamente o pagamento resultante para duas casas decimais.
 
 
-**Exercício 4: uponha que executamos as seguintes declaração por atribuição:**
+**Exercício 4: Suponha que executamos as seguintes declaração por atribuição:**
 
 ~~~~
 Largura = 17


### PR DESCRIPTION
Era apenas um S faltando no começo do enunciado do exercício 4