### PR TITLE
Ajuste dos termos instrução e declaração

### DIFF
--- a/book3/02-variables.mkd
+++ b/book3/02-variables.mkd
@@ -91,13 +91,13 @@ Variáveis
 ---------
 
 \index{variável}
-\index{declaração por atribuição}
+\index{atribuição por declaração}
 \index{declaração!atribuição}
 
 
 Um dos recursos mais poderosos da linguagem de programação é a capacidade de manipular *variáveis*. Uma variável é um nome que faz referência a um valor.
 
-Uma *declaração por atribuição* cria novas variáveis e atribui valores a elas:
+Uma *atribuição por declaração* cria novas variáveis e atribui valores a elas:
 
 ~~~~ {.python}
 >>> message = 'E agora, para algo completamente diferente'
@@ -182,7 +182,7 @@ Declarações
 ----------
 
 
- Uma *declaração* é uma unidade do código que o Python interpreta e pode executar. Nós vimos dois tipos de declarações: print como uma declaração ou uma atribuição. 
+ Uma *declaração* é uma unidade do código que o Python interpreta e pode executar. Nós vimos dois tipos de declarações: print como uma instrução ou uma atribuição. 
 
 \index{declaração}
 \index{modo interativo}
@@ -190,7 +190,7 @@ Declarações
 
 Quando você digita uma declaração no modo interativo, o interpretador  a executa e exibe os resultados, se houver um.
 
-Um  script geralmente contém uma sequência de declarações. Se houver mais de uma declaração, os resultados aparecerão à medida que as instruções são executadas.
+Um  script geralmente contém uma sequência de declarações. Se houver mais de uma declaração, os resultados aparecerão à medida que elas são executadas.
 
 
 \index{statement}
@@ -214,7 +214,7 @@ produz a saída
 2
 ~~~~
 
-A declaração por atribuição não produz saída.
+A atribuição por declaração não produz saída.
 
 Operadores e operandos
 ----------------------


### PR DESCRIPTION
Statement estava sempre sendo traduzido como "declaração", mas alterei para "instrução" conforme o contexto